### PR TITLE
[FIX] 반환 데이터 타입 불일치 수정

### DIFF
--- a/src/main/kotlin/com/entrip/domain/dto/Comments/CommentsWithPlanReturnDto.kt
+++ b/src/main/kotlin/com/entrip/domain/dto/Comments/CommentsWithPlanReturnDto.kt
@@ -2,9 +2,9 @@ package com.entrip.domain.dto.Comments
 
 import com.entrip.domain.dto.Plans.PlansReturnDto
 
-class CommentsWithPlanReturnDto (
-    val planReturnDto: PlansReturnDto,
-    val commentsList: MutableList<CommentsReturnDto> = ArrayList<CommentsReturnDto>()
+class CommentsWithPlanReturnDto(
+    val planReturnDto: PlansReturnDto?,
+    val commentsList: MutableList<CommentsReturnDto>? = ArrayList<CommentsReturnDto>()
     ){
 
 }

--- a/src/main/kotlin/com/entrip/service/CommentsService.kt
+++ b/src/main/kotlin/com/entrip/service/CommentsService.kt
@@ -95,7 +95,7 @@ class CommentsService(
     public fun save(requestDto: CommentsSaveRequestDto): CommentsWithPlanReturnDto {
         val plan_id = requestDto.plans_id
         val plans: Plans = plansRepository.findById(plan_id!!).orElseThrow {
-            NotAcceptedException("Error raise at plansRepository.findById$plan_id")
+            NotAcceptedException(CommentsWithPlanReturnDto(null, null))
         }
         val users = findUsers(requestDto.author)
         val comments = requestDto.toEntity()
@@ -125,7 +125,7 @@ class CommentsService(
 
     public fun delete(comment_id: Long): CommentsWithPlanReturnDto {
         val comments: Comments = commentsRepository.findById(comment_id!!).orElseThrow {
-            NotAcceptedException("Error raise at commentsRepository.findById$comment_id")
+            NotAcceptedException(CommentsWithPlanReturnDto(null, null))
         }
         val plan_id = comments.plans?.plan_id
         comments.plans?.planners?.setComment_timeStamp()


### PR DESCRIPTION
- 202코드 날릴 때도 CommentsWithPlanReturnDto 타입으로 반환하되, null로 값 채워 반환하도록 함