### PR TITLE
[FIX] (XAEX-89) 이전 투표 목록 반환 api 수정

### DIFF
--- a/src/main/kotlin/com/entrip/controller/VotesController.kt
+++ b/src/main/kotlin/com/entrip/controller/VotesController.kt
@@ -80,7 +80,7 @@ class VotesController(
         return sendResponseHttpByJson("successfully undoVoted at $voteId", returnDto)
     }
 
-    @GetMapping("api/v1/votes/getPreviousVotes")
+    @PostMapping("api/v1/votes/getPreviousVotes")
     fun getPreviousVotes(@RequestBody requestDto: PreviousVotesContentsRequestDto) : ResponseEntity<RestAPIMessages> {
         val user_id = requestDto.user_id
         val returnDto = votesContentsService.getPreviousVoteContents(requestDto)


### PR DESCRIPTION
- 클라이언트에서 GET일때 body를 못실어서 보내는 이슈로 GET -> POST 로 변경